### PR TITLE
Replace Kinetics400 with Kinetics 

### DIFF
--- a/classy_vision/dataset/classy_kinetics400.py
+++ b/classy_vision/dataset/classy_kinetics400.py
@@ -8,7 +8,7 @@ import os
 from typing import Any, Callable, Dict, List, Optional
 
 import torch
-from torchvision.datasets.kinetics import Kinetics400
+from torchvision.datasets.kinetics import Kinetics
 
 from . import register_dataset
 from .classy_video_dataset import ClassyVideoDataset
@@ -91,7 +91,7 @@ class Kinetics400Dataset(ClassyVideoDataset):
                 metadata_filepath, video_dir=video_dir, update_file_path=True
             )
 
-        dataset = Kinetics400(
+        dataset = Kinetics(
             video_dir,
             frames_per_clip,
             step_between_clips=step_between_clips,


### PR DESCRIPTION
Kinetics400 class is removed in latest torchvision(https://github.com/pytorch/vision/commit/7b8a6db7f450e70a1e0fb07e07b30dda6a7e6e1c#diff-a3b7f6a28cb8cc57cf284dbd9fd430d5a6a1b4917bceca13676a90d90a16aaa8L251) which is causing an error. This PR replaces Kinetics400 with Kinetics class to resolve it.